### PR TITLE
Update bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,10 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**Preconditions**
+The necesarry actions to perform before executing the steps.
+
+**Steps to reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -20,8 +23,11 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Actual behavior**
+A clear and concise description of what is actually happening.
+
+**Screenshots/Screencasts**
+If applicable, add screenshots or screencasts to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **Preconditions**
-The necesarry actions to perform before executing the steps.
+The necessary actions to perform before executing the steps.
 
 **Steps to reproduce**
 Steps to reproduce the behavior:


### PR DESCRIPTION
Added the following fields:
- Preconditions - Acts as an optional field and should be completed if some prerequisites/setup needs to be performed before executing the actual steps in order to reproduce the issue.
- Actual behavior - This describes the actual problem/bug after executing the steps to reproduce.

Reworded:
- To Reproduce in Steps to reproduce
- Screenshots to Screenshots/Screencasts. Also updated the description to let users know that they can upload screencasts to GH tickets as well.